### PR TITLE
Added min_df = 5 in TF/TF-IDF embeddings questions

### DIFF
--- a/HW2.ipynb
+++ b/HW2.ipynb
@@ -131,7 +131,7 @@
    },
    "source": [
     "#### 2. (6 points) TF Embedding\n",
-    "Calculate the term frequency embedding of the KimKardashian tweets.  \n",
+    "Calculate the term frequency embedding of the KimKardashian tweets. Note: Use min_df = 5 and english stopwords here. \n",
     "\n",
     "How big is the vocabulary?  Print your answer."
    ]
@@ -316,7 +316,7 @@
    "source": [
     "#### 2. (6 points) TF-IDF Embedding\n",
     "\n",
-    "Calculate the term frequency inverse document frequency (tf-idf) embedding of the tweets.  How big is the vocabulary?  Print your answer."
+    "Calculate the term frequency inverse document frequency (tf-idf) embedding of the tweets.  How big is the vocabulary?  Print your answer.  Note: Use min_df = 5 and english stopwords here. "
    ]
   },
   {


### PR DESCRIPTION
Students often used min_df=0 instead of 5, and this led to different results for vocabulary calculations. Specifying min_df = 5 would help clarify this directly.